### PR TITLE
Make ParseMarkdown() take an io.Reader so it can handle reading from more than a file.

### DIFF
--- a/example.go
+++ b/example.go
@@ -2,13 +2,19 @@ package json_markd
 
 import (
 	"fmt"
+	"os"
 )
 
 // Example usage for json_markd
 func main() {
 	SetTabSpaceValue(2)
 	SetupLogger()
-	result, err := ParseMarkdown("data/sample_api.md")
+	f, err := os.Open("data/sample_api.md")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	result, err := ParseMarkdown(f)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/parser.go
+++ b/parser.go
@@ -5,6 +5,7 @@ package json_markd
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strings"
 )
@@ -29,9 +30,9 @@ func SetTabSpaceValue(val int) {
 }
 
 // ParseMarkdown accepts a filepath to a markdown file and return JSON string for same
-func ParseMarkdown(filepath string) (string, error) {
+func ParseMarkdown(src io.Reader) (string, error) {
 	SetupLogger()
-	markdownData, err := ioutil.ReadFile(filepath)
+	markdownData, err := ioutil.ReadAll(src)
 	if err != nil {
 		fmt.Println("File reading error", err)
 		return "", err

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,6 +2,7 @@ package json_markd
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,10 @@ func TestParseMarkdown(t *testing.T) {
 	t.Run("when correct file is passed", func(t *testing.T) {
 		t.Run("it should return correct response", func(t *testing.T) {
 			expectedResponse := "{\n  \"data\" : {\n    \"name\" : \"random string\",\n    \"age\" : 0,\n    \"income\" : 0.0,\n    \"vehicles\" : [\n      {\n        \"name\" : \"random string\",\n        \"price\" : 0.0\n      }\n    ],\n    \"apps\" : [\n      [\n        \"random string\",\n        \"random string\"\n      ],\n      [\n        \"random string\",\n        \"random string\"\n      ]\n    ]\n  },\n  \"errors\" : {\n    \"type\" : \"random string\"\n  }\n}"
-			result, _ := ParseMarkdown("./test_data/sample.md")
+			const filePath = "./test_data/sample.md"
+			f, err := os.Open(filePath)
+			assert.NoError(t, err, "failed to open file: %s", filePath)
+			result, _ := ParseMarkdown(f)
 			assert.Equal(t, expectedResponse, result)
 		})
 	})
@@ -48,7 +52,14 @@ func TestParseMarkdown(t *testing.T) {
 	t.Run("when incorrect file is passed", func(t *testing.T) {
 		t.Run("it should return correct response", func(t *testing.T) {
 			expectedResponse := "open ./test_data/sample_1.md: no such file or directory"
-			_, err := ParseMarkdown("./test_data/sample_1.md")
+			const filePath = "./test_data/sample_1.md"
+			f, err := os.Open(filePath)
+			assert.Equal(t, expectedResponse, err.Error())
+			if err != nil {
+				return
+			}
+			expectedResponse = "invalid argument"
+			_, err = ParseMarkdown(f)
 			assert.Equal(t, expectedResponse, err.Error())
 		})
 	})
@@ -56,7 +67,10 @@ func TestParseMarkdown(t *testing.T) {
 	t.Run("when file data is invalid", func(t *testing.T) {
 		t.Run("it should return correct response", func(t *testing.T) {
 			expectedResponse := ".errors.invalid_markdown_list_format"
-			_, err := ParseMarkdown("./test_data/sample_invalid.md")
+			const filePath = "./test_data/sample_invalid.md"
+			f, err := os.Open(filePath)
+			assert.NoError(t, err, "failed to open file: %s", filePath)
+			_, err = ParseMarkdown(f)
 			assert.Equal(t, expectedResponse, err.Error())
 		})
 	})


### PR DESCRIPTION
Hello, was looking for a markdown converter and came across your package. I need to read markdown from more than a file, so here's a PR that makes `ParseMarkdown()` take an io.Reader instead of a file path.